### PR TITLE
Make Swift example not gross

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,18 +177,18 @@ import XCTest
 
 class BridgeTest: XCTestCase {
   func testBridge() {
-    let expectation = XCTestExpectation(description: "Cavy tests passed");
+    let expectation = XCTestExpectation(description: "Cavy tests passed")
 
     CavyNativeReporter.onFinish { report in
-      NSLog("%@", report);
-      let errorCount = report["errorCount"] as! Int;
-      if (errorCount > 0) {
-        XCTFail("Cavy tests had one or more errors");
+      NSLog("%@", report)
+      let errorCount = report["errorCount"] as? Int ?? 0
+      if errorCount > 0 {
+        XCTFail("Cavy tests had one or more errors")
       }
-      expectation.fulfill();
+      expectation.fulfill()
     }
 
-    wait(for: [expectation], timeout: 5);
+    wait(for: [expectation], timeout: 5)
   }
 }
 ```


### PR DESCRIPTION
Ugh, semicolons! ;) fixed up readme to show idiomatic Swift