### PR TITLE
Update CavyNativeReporter.podspec

### DIFF
--- a/ios/CavyNativeReporter.podspec
+++ b/ios/CavyNativeReporter.podspec
@@ -4,9 +4,9 @@ Pod::Spec.new do |s|
   s.version      = "0.1.0"
   s.summary      = "CavyNativeReporter"
   s.description  = <<-DESC
-                  CavyNativeReporter
+                  CavyNativeReporter - A native test reporter for Cavy
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/pixielabs/cavy-native-reporter"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Removes missing required attribute error and description warning shown while running `pod install`

```
[!] The `CavyNativeReporter` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | description: The description is equal to the summary.
```