### PR TITLE
fix(ios, podspec): Use package.json values, fix source ref, depend on React-Core

### DIFF
--- a/ios/CavyNativeReporter.podspec
+++ b/ios/CavyNativeReporter.podspec
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.author       = { "author" => "dev@pixielabs.io" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/CavyNativeReporter.git", :tag => "master" }
-  s.source_files  = "CavyNativeReporter/**/*.{h,m}"
+  s.source       = { :git => "https://github.com/pixielabs/cavy-native-reporter.git", :tag => "v#{s.version}" }
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
   s.dependency "React-Core"
 end

--- a/ios/CavyNativeReporter.podspec
+++ b/ios/CavyNativeReporter.podspec
@@ -1,15 +1,13 @@
+package = JSON.parse(File.read(File.join(__dir__, (File.join('..', 'package.json')))))
 
 Pod::Spec.new do |s|
   s.name         = "CavyNativeReporter"
-  s.version      = "0.1.0"
-  s.summary      = "CavyNativeReporter"
-  s.description  = <<-DESC
-                  CavyNativeReporter - A native test reporter for Cavy
-                   DESC
+  s.version      = package["version"]
+  s.description  = package["description"]
+  s.summary      = s.name
   s.homepage     = "https://github.com/pixielabs/cavy-native-reporter"
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.license      = package["license"]
+  s.author       = { "author" => "dev@pixielabs.io" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/CavyNativeReporter.git", :tag => "master" }
   s.source_files  = "CavyNativeReporter/**/*.{h,m}"

--- a/ios/CavyNativeReporter.podspec
+++ b/ios/CavyNativeReporter.podspec
@@ -12,9 +12,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/author/CavyNativeReporter.git", :tag => "master" }
   s.source_files  = "CavyNativeReporter/**/*.{h,m}"
   s.requires_arc = true
-
-
-  s.dependency "React"
-  #s.dependency "others"
-
+  s.dependency "React-Core"
 end


### PR DESCRIPTION

Hi there!

These fixes were needed to successfully use the cavy-native-reporter over at https://notifee.app, specifically without fixing the source reference iOS failed to work (though Android was fine)

With these, the podspec may remain static while just updating package.json values, and it works on iOS

Each of the 3 commits is intended to do a specific thing along with a specific comment explaining why, so might be easiest as a maintainer to roll the commits one by one, but that's just my preference when I'm doing PR review so I tried to be the PR proposer I like getting myself ;-)

Cheers